### PR TITLE
DOC: Use :recursive: option with autosummary, fix refs

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -4,9 +4,10 @@ API Reference
 =============
 
 .. automodule:: vocalpy
-.. currentmodule:: vocalpy
 
 This section documents the vocalpy `API <https://en.wikipedia.org/wiki/API>`_.
+
+.. currentmodule:: vocalpy
 
 Data types
 ----------
@@ -40,6 +41,7 @@ Signal processing
 
 .. autosummary::
    :toctree: generated
+   :recursive:
    :template: module.rst
 
    signal
@@ -51,6 +53,7 @@ Metrics
 .. autosummary::
    :toctree: generated
    :template: module.rst
+   :recursive:
 
    metrics
    metrics.segmentation
@@ -72,6 +75,7 @@ Visualization
 .. autosummary::
    :toctree: generated
    :template: module.rst
+   :recursive:
 
    plot
 
@@ -81,9 +85,8 @@ Other
 .. autosummary::
    :toctree: generated
    :template: module.rst
+   :recursive:
 
    constants
    validators
    paths
-
-

--- a/src/vocalpy/segmenter.py
+++ b/src/vocalpy/segmenter.py
@@ -28,7 +28,7 @@ class Segmenter:
         The function or :class:`Callable` class instance
         that is used to segment.
         If not specified, defaults to
-        :func:`vocalpy.segment.audio_amplitude.audio_amplitude`.
+        :func:`vocalpy.segment.energy`.
     method : str, optional.
         The name of the function to use to segment.
     segment_params : dict, optional.
@@ -44,7 +44,7 @@ class Segmenter:
             The function or :class:`Callable` class instance
             that is used to segment.
             If not specified, defaults to
-            :func:`vocalpy.segment.audio_amplitude.audio_amplitude`.
+            :func:`vocalpy.segment.energy`.
         method : str, optional.
             The name of the function to use to segment.
         segment_params : dict, optional.

--- a/src/vocalpy/sequence.py
+++ b/src/vocalpy/sequence.py
@@ -18,7 +18,7 @@ class Sequence:
     units : list
         A :class:`list` of `vocalpy.Unit` instances.
         Produced by segmenting audio, e.g. with
-        :func:`vocalpy.signal.segment.segment_audio_amplitude`.
+        :func:`vocalpy.segment.energy`.
     segment_method : str
         The method used to segment audio.
         Either a string name of a method


### PR DESCRIPTION
Adds :recursive: option to autosummary in API docs so, and fixes a couple :func: references in docstrings