### PR TITLE
BUG: Fix return values for precision_recall_fscore

### DIFF
--- a/src/vocalpy/metrics/segmentation/ir.py
+++ b/src/vocalpy/metrics/segmentation/ir.py
@@ -312,7 +312,7 @@ def precision_recall_fscore(
 
     # If we have no boundaries, we get no score.
     if len(reference) == 0 or len(hypothesis) == 0:
-        return 0.0, 0, IRMetricData()
+        return 0.0, 0, IRMetricData(hits_ref=np.array([]), hits_hyp=np.array([]), diffs=np.array([]))
 
     hits_ref, hits_hyp, diffs = find_hits(hypothesis, reference, tolerance, decimals)
     metric_data = IRMetricData(hits_ref, hits_hyp, diffs)


### PR DESCRIPTION
When there are no boundaries then the score is 0,
but we get an error because we don't pass any values into IRMetrics. I'm choosing to fix this for now by returning an IRMetrics where all the arrays are empty.
I'd rather do this "by hand" in the return values of this function, then have the dataclass have an optional None value -- not sure right now if we want a default value.
No downstream functions use these values, they're just for a user's analysis, so I don't think it would hurt anything, but just to be sure I'll fix like this for now.