### PR TITLE
BUG/ENH: Fix boundary validation, fixes #79

### DIFF
--- a/src/vocalpy/validators/validators.py
+++ b/src/vocalpy/validators/validators.py
@@ -54,9 +54,9 @@ def is_1d_ndarray(y: npt.NDArray, name: str | None = None) -> bool:
 
 
 def is_valid_boundaries_array(y: npt.NDArray, name: str | None = None) -> bool:
-    """Validates that ``y`` is a valid array of boundaries,
-    i.e., onsets or offsets of segments such as those
-    found with a segmentation algorithm.
+    """Validates that ``y`` is a valid array of boundaries
+    found with a segmentation algorithm,
+    e.g., onsets or offsets of segments returned by :func:`vocalpy.segment.meansquared`.
 
     To be a valid array of boundaries, ``y`` must meet the following conditions:
     - Be a one dimensional numpy array, as validated with
@@ -64,6 +64,9 @@ def is_valid_boundaries_array(y: npt.NDArray, name: str | None = None) -> bool:
     - Have a dtype that is a float or int, e.g. ``np.float64`` or ``np.int32``.
     - Have values that are all non-negative, i.e. ``np.all(y >= 0.0)``
     - Have values that are strictly increasing, i.e. ``np.all(y[1:] > y[:-1])``
+
+    An empty array or an array with a single value are also considered valid,
+    as long as the dtype is correct and any value is non-negative.
 
     Parameters
     ----------
@@ -77,6 +80,17 @@ def is_valid_boundaries_array(y: npt.NDArray, name: str | None = None) -> bool:
     -------
     is_valid_boundaries_array: bool
         True if ``y`` is valid.
+
+    Examples
+    --------
+    >>> vocalpy.validators.is_valid_boundaries_array(np.array([1, 2, 3], dtype=np.int16))
+    True
+    >>> vocalpy.validators.is_valid_boundaries_array(np.array([1.0, 2.0, 3.0], dtype=np.float32))
+    True
+    >>> vocalpy.validators.is_valid_boundaries_array(np.array([], dtype=np.float32))
+    True
+    >>> vocalpy.validators.is_valid_boundaries_array(np.array([1.0], dtype=np.float32))
+    True
     """
     is_1d_ndarray(y, name)
 
@@ -90,6 +104,11 @@ def is_valid_boundaries_array(y: npt.NDArray, name: str | None = None) -> bool:
 
     if not np.all(y >= 0.0):
         raise ValueError(f"Values of boundaries array {name}must all be non-negative")
+
+    if y.size <= 1:
+        # It's a valid boundary array but there's no boundaries or just one boundary,
+        # so we don't check that values are strictly increasing
+        return True
 
     if not np.all(y[1:] > y[:-1]):
         raise ValueError(f"Values of boundaries array {name}must be strictly increasing")

--- a/tests/test_metrics/test_segmentation/test_ir.py
+++ b/tests/test_metrics/test_segmentation/test_ir.py
@@ -498,6 +498,59 @@ IR_METRICS_SINGLE_BOUNDARY_ARRAY_PARAMS_VALS = [
         expected_recall=1.0,
         expected_fscore=0.5454545454545454,
     ),
+    # # edge cases
+    # no boundaries in either
+    IRMetricSingleBoundaryArrayTestCase(
+        reference=np.array([]),
+        hypothesis=np.array([]),
+        tolerance=0.5,
+        decimals=3,
+        expected_hits_ref=np.array([]),
+        expected_hits_hyp=np.array([]),
+        expected_diffs=np.array([]),
+        expected_precision=0.0,
+        expected_recall=0.0,
+        expected_fscore=0.0,
+    ),
+    # no boundaries in reference
+    IRMetricSingleBoundaryArrayTestCase(
+        reference=np.array([]),
+        hypothesis=np.array([1.0, 2.0, 3.0]),
+        tolerance=0.5,
+        decimals=3,
+        expected_hits_ref=np.array([]),
+        expected_hits_hyp=np.array([]),
+        expected_diffs=np.array([]),
+        expected_precision=0.0,
+        expected_recall=0.0,
+        expected_fscore=0.0,
+    ),
+    # no boundaries in hypothesis
+    IRMetricSingleBoundaryArrayTestCase(
+        reference=np.array([1.0, 2.0, 3.0]),
+        hypothesis=np.array([]),
+        tolerance=0.5,
+        decimals=3,
+        expected_hits_ref=np.array([]),
+        expected_hits_hyp=np.array([]),
+        expected_diffs=np.array([]),
+        expected_precision=0.0,
+        expected_recall=0.0,
+        expected_fscore=0.0,
+    ),
+    # only one boundary in ref/hyp
+    IRMetricSingleBoundaryArrayTestCase(
+        reference=np.array([1.0]),
+        hypothesis=np.array([1.0]),
+        tolerance=0.5,
+        decimals=3,
+        expected_hits_ref=np.array([0]),
+        expected_hits_hyp=np.array([0]),
+        expected_diffs=np.array([0]),
+        expected_precision=1.0,
+        expected_recall=1.0,
+        expected_fscore=1.0,
+    ),
 ]
 
 

--- a/tests/test_validators/test_validators.py
+++ b/tests/test_validators/test_validators.py
@@ -53,6 +53,15 @@ def test_is_1d_ndarray_raises_value_error(y):
     [
         np.array([1, 2, 3]),
         np.array([1.0, 2.0, 3.0]),
+        # ---- edge cases
+        # empty arrays are valid boundary arrays,
+        # e.g. when we segment but don't find any boundaries
+        np.array([], dtype=np.float32),
+        np.array([], dtype=np.int16),
+        # a single boundary is still a valid boundary array
+        # e.g for segmenting algorithms that threshold a distance measure
+        np.array([1]),
+        np.array([1.0]),
     ]
 )
 def test_is_valid_boundaries_array(y):


### PR DESCRIPTION
* Fixes `vocalpy.validators.is_valid_boundaries_array` to handle the case where there's only one boundary in the array
* Also makes it so that an empty array is considered valid; we choose to consider this valid since some segmentation algorithms will return an empty array in some cases, e.g. when there are no time periods above a threshold