### PR TITLE
issue #100 patch — update hardcoded value in vocalpy.spectral.sat.py

### DIFF
--- a/src/vocalpy/spectral/sat.py
+++ b/src/vocalpy/spectral/sat.py
@@ -95,7 +95,7 @@ def sat(
     # ---- make power spec
     audio_pad = np.pad(audio.data, pad_width=n_fft // 2)
     windows = librosa.util.frame(audio_pad, frame_length=n_fft, hop_length=hop_length, axis=0)
-    tapers = scipy.signal.windows.dpss(400, 1.5, Kmax=2)
+    tapers = scipy.signal.windows.dpss(n_fft, 1.5, Kmax=2)
     windows1 = windows * tapers[0, :]
     windows2 = windows * tapers[1, :]
 


### PR DESCRIPTION
Addresses bug outlined in #100. Update hardcoded value (400) to `n_fft` argument:

`tapers = scipy.signal.windows.dpss(n_fft, 1.5, Kmax=2)`