### PR TITLE
ENH: Add trough_threshold parameter to feature.sat.pitch

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -91,7 +91,8 @@ autosummary_ignore_module_all = False
 # -- Options for intersphinx extension ---------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = intersphinx_mapping = {
+intersphinx_mapping = {
+    "librosa": ("https://librosa.org/doc/0.10.0", None),
     "python": ("https://docs.python.org/3/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),

--- a/src/vocalpy/__init__.py
+++ b/src/vocalpy/__init__.py
@@ -27,7 +27,6 @@ from .spectrogram_maker import SpectrogramMaker
 from .spectrogram_parameters import SpectrogramParameters
 from .unit import Unit
 
-
 __all__ = [
     "__author__",
     "__commit__",

--- a/src/vocalpy/_spectrogram/data_type.py
+++ b/src/vocalpy/_spectrogram/data_type.py
@@ -143,24 +143,24 @@ class Spectrogram:
     @classmethod
     def read(cls, path: str | pathlib.Path, audio_path: str | pathlib.Path | None = None):
         """Read spectrogram and associated arrays from a Numpy npz file
-        at the given ``path``.
+            at the given ``path``.
 
-        Parameters
-        ----------
-        path : str, pathlib.Path
-            The path to the file containing the spectrogram ``s``
-            and associated arrays ``f`` and ``t``.
-    audio_path : str or pathlib.Path, optional
-        Path to audio file from which spectrogram was generated.
-        Optional, default None. Note this argument is not validated
-        (to guarantee that the spectrogram was actually generated
-        from the specified audio path.)
+            Parameters
+            ----------
+            path : str, pathlib.Path
+                The path to the file containing the spectrogram ``s``
+                and associated arrays ``f`` and ``t``.
+        audio_path : str or pathlib.Path, optional
+            Path to audio file from which spectrogram was generated.
+            Optional, default None. Note this argument is not validated
+            (to guarantee that the spectrogram was actually generated
+            from the specified audio path.)
 
-        Returns
-        -------
-        spect : vocalpy.Spectrogram
-            An instance of :class:`vocalpy.Spectrogram`
-            containing the arrays loaded from ``path``.
+            Returns
+            -------
+            spect : vocalpy.Spectrogram
+                An instance of :class:`vocalpy.Spectrogram`
+                containing the arrays loaded from ``path``.
         """
         path = pathlib.Path(path)
         if not path.exists():

--- a/src/vocalpy/examples/__init__.py
+++ b/src/vocalpy/examples/__init__.py
@@ -1,7 +1,6 @@
 """Example data built into VocalPy."""
 from ._registry import example, list
 
-
 __all__ = [
     "example",
     "list",

--- a/src/vocalpy/examples/_registry.py
+++ b/src/vocalpy/examples/_registry.py
@@ -2,9 +2,8 @@
 from __future__ import annotations
 
 import importlib.resources
-from typing import TYPE_CHECKING
-
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     import vocalpy
@@ -19,42 +18,39 @@ class Example:
 
 EXAMPLES = [
     Example(
-        name='bells.wav',
-        metadata='Zebra finch song from Sound Analysis Pro website: http://soundanalysispro.com/',
-        type='audio'
+        name="bells.wav",
+        metadata="Zebra finch song from Sound Analysis Pro website: http://soundanalysispro.com/",
+        type="audio",
     ),
     Example(
-        name='flashcam.wav',
-        metadata='Zebra finch song from Sound Analysis Pro website: http://soundanalysispro.com/',
-        type='audio'
+        name="flashcam.wav",
+        metadata="Zebra finch song from Sound Analysis Pro website: http://soundanalysispro.com/",
+        type="audio",
     ),
     Example(
-        name='samba.wav',
-        metadata='Zebra finch song from Sound Analysis Pro website: http://soundanalysispro.com/',
-        type='audio'
+        name="samba.wav",
+        metadata="Zebra finch song from Sound Analysis Pro website: http://soundanalysispro.com/",
+        type="audio",
     ),
     Example(
-        name='simple.wav',
-        metadata='Zebra finch song from Sound Analysis Pro website: http://soundanalysispro.com/',
-        type='audio'
+        name="simple.wav",
+        metadata="Zebra finch song from Sound Analysis Pro website: http://soundanalysispro.com/",
+        type="audio",
     ),
     Example(
-        name='BM003.wav',
+        name="BM003.wav",
         metadata="""Mouse ultrasonic vocalization from:
-Goffinet, J., Brudner, S., Mooney, R., & Pearson, J. (2021). 
-Data from: Low-dimensional learned feature spaces quantify individual and group differences 
+Goffinet, J., Brudner, S., Mooney, R., & Pearson, J. (2021).
+Data from: Low-dimensional learned feature spaces quantify individual and group differences
 in vocal repertoires. Duke Research Data Repository. https://doi.org/10.7924/r4gq6zn8w.
 Adapted under Creative Commons License 1.0: https://creativecommons.org/publicdomain/zero/1.0/.
 File name in dataset: BM003_day9_air_20s_sparse_chunk007_0297.wav""",
-        type='audio'
+        type="audio",
     ),
 ]
 
 
-REGISTRY = {
-    example.name: example
-    for example in EXAMPLES
-}
+REGISTRY = {example.name: example for example in EXAMPLES}
 
 
 def example(name: str) -> vocalpy.Audio:
@@ -90,19 +86,15 @@ def example(name: str) -> vocalpy.Audio:
     >>> voc.plot.spect(spect)
     """
     if name not in REGISTRY:
-        raise ValueError(
-            f"No example found with name: {name}. "
-            f"For a list of examples, call "
-        )
+        raise ValueError(f"No example found with name: {name}. " f"For a list of examples, call ")
     example_ = REGISTRY[name]
     path = importlib.resources.files("vocalpy.examples").joinpath(name)
-    if example_.type == 'audio':
+    if example_.type == "audio":
         import vocalpy
+
         return vocalpy.Audio.read(path)
     else:
-        raise ValueError(
-            f"The ``type`` for the example was invalid: {example_.type}"
-        )
+        raise ValueError(f"The ``type`` for the example was invalid: {example_.type}")
 
 
 def list():
@@ -127,8 +119,4 @@ def list():
     print("Examples built into VocalPy")
     print("=" * 72)
     for example in EXAMPLES:
-        print(
-            f"name: {example.name}\n"
-            "metadata:\n"
-            f"{example.metadata}\n"
-        )
+        print(f"name: {example.name}\n" "metadata:\n" f"{example.metadata}\n")

--- a/src/vocalpy/feature/sat.py
+++ b/src/vocalpy/feature/sat.py
@@ -304,7 +304,14 @@ def amplitude(
     return 10 * np.log10(np.sum(P, axis=0)) + baseline
 
 
-def pitch(audio: Audio, fmin: float = 380.0, fmax_yin: float = 8000.0, frame_length: int = 400, hop_length: int = 40, trough_threshold: float = 0.1 ):
+def pitch(
+    audio: Audio,
+    fmin: float = 380.0,
+    fmax_yin: float = 8000.0,
+    frame_length: int = 400,
+    hop_length: int = 40,
+    trough_threshold: float = 0.1,
+):
     """Estimates the fundamental frequency (or pitch) using the YIN algorithm.
 
     Returns:
@@ -355,7 +362,7 @@ def pitch(audio: Audio, fmin: float = 380.0, fmax_yin: float = 8000.0, frame_len
         sr=audio.samplerate,
         frame_length=frame_length,
         hop_length=hop_length,
-       trough_threshold=trough_threshold
+        trough_threshold=trough_threshold,
     )
 
 

--- a/src/vocalpy/feature/sat.py
+++ b/src/vocalpy/feature/sat.py
@@ -312,14 +312,14 @@ def pitch(
     hop_length: int = 40,
     trough_threshold: float = 0.1,
 ):
-    """Estimates the fundamental frequency (or pitch) using the YIN algorithm.
+    """Estimates the fundamental frequency (or pitch) using the YIN algorithm [1]_.
 
-    Returns:
-        np.array: array containing the YIN estimated fundamental frequency of each frame in the song interval in Hertz.
+    The pitch is computed using :func:`librosa.yin`.
 
     Parameters
     ----------
     audio : vocalpy.Audio
+        A :class:`vocalpy.Audio` instance.
     fmin : float
         Minimum frequency in Hertz.
         The recommended minimum is ``librosa.note_to_hz('C2')`` (~65 Hz)
@@ -334,26 +334,32 @@ def pitch(
         number of audio samples between adjacent YIN predictions.
         If ``None``, defaults to ``frame_length // 4``.
         Default is 40.
-    trough_threshold: float > 0
-        absolute threshold for peak estimation.
+    trough_threshold: float
+        Absolute threshold for peak estimation.
+        A float greater than 0.
 
     Returns
     -------
+    pitch: np.array
+        Time series of fundamental frequency in Hertz.
 
     Notes
     -----
     For more information on the YIN algorithm for fundamental frequency estimation,
     please refer to the documentation for :func:`librosa.yin`.
 
-    Code adapted from [1]_, [2]_, and [3]_.
-    Docs adapted from [1]_ and [3]_.
+    Code adapted from [2]_, [3]_, and [4]_.
+    Docs adapted from [2]_ and [4]_.
 
     References
     ----------
-    .. [1] `Sound Analysis Tools <http://soundanalysispro.com/matlab-sat>`_ for Matlab (SAT) by Ofer Tchernichovski
-    .. [2] `birdsonganalysis <https://github.com/PaulEcoffet/birdsonganalysis>`_  by Paul Ecoffet
-    .. [3] `avn <https://github.com/theresekoch/avn/blob/main/avn/acoustics.py>`_
-       by Therese Koch, specifically the acoustics module
+    .. [1] De Cheveigné, Alain, and Hideki Kawahara.
+           “YIN, a fundamental frequency estimator for speech and music.”
+           The Journal of the Acoustical Society of America 111.4 (2002): 1917-1930.
+    .. [2] `Sound Analysis Tools <http://soundanalysispro.com/matlab-sat>`_ for Matlab (SAT) by Ofer Tchernichovski
+    .. [3] `birdsonganalysis <https://github.com/PaulEcoffet/birdsonganalysis>`_  by Paul Ecoffet
+    .. [4] `avn <https://github.com/theresekoch/avn/blob/main/avn/acoustics.py>`_
+           by Therese Koch, specifically the acoustics module
     """
     return librosa.yin(
         audio.data,

--- a/src/vocalpy/feature/sat.py
+++ b/src/vocalpy/feature/sat.py
@@ -432,8 +432,9 @@ def similarity_features(
         audio, n_fft, hop_length, freq_range
     )
     amp_ = amplitude(power_spectrogram, min_freq, max_freq, amp_baseline)
-    pitch_ = pitch(audio, min_freq, fmax_yin,
-                   frame_length=n_fft, hop_length=hop_length, trough_threshold=trough_threshold)
+    pitch_ = pitch(
+        audio, min_freq, fmax_yin, frame_length=n_fft, hop_length=hop_length, trough_threshold=trough_threshold
+    )
     goodness_ = goodness_of_pitch(cepstrogram, quefrencies, max_F0)
     FM = frequency_modulation(dSdt, dSdf)
     AM = amplitude_modulation(dSdt)

--- a/src/vocalpy/feature/sat.py
+++ b/src/vocalpy/feature/sat.py
@@ -383,11 +383,11 @@ def similarity_features(
     fmax_yin: float = 8000.0,
     trough_threshold: float = 0.1,
 ) -> xr.DataSet:
-    """Extract all features used to compute simlarity with SAT.
+    """Extract all features used to compute similarity with SAT.
 
     Calls :func:`vocalpy.spectral.sat` to get spectral representations
-    of `vocalpy.Audio` that are used to extract features,
-    and then extracts all features.
+    of the :class:`vocalpy.Audio`, then extracts all features
+    from those spectral representations.
 
     Parameters
     ----------

--- a/src/vocalpy/feature/sat.py
+++ b/src/vocalpy/feature/sat.py
@@ -381,6 +381,7 @@ def similarity_features(
     amp_baseline: float = 70.0,
     max_F0: int = 1830.0,
     fmax_yin: float = 8000.0,
+    trough_threshold: float = 0.1,
 ) -> xr.DataSet:
     """Extract all features used to compute simlarity with SAT.
 
@@ -407,8 +408,7 @@ def similarity_features(
         Minimum frequency to consider when extracting features.
     amp_baseline : float
         The baseline value added, in decibels, to the amplitude feature.
-        The default is 70.0 dB, the value used by SAT
-        and SAP.
+        The default is 70.0 dB, the value used by SAT and SAP.
     max_F0 : float
         Maximum frequency to consider,
         that becomes the lowest ``quefrency``
@@ -416,6 +416,10 @@ def similarity_features(
     fmax_yin : float
         Maximum frequency in Hertz when computing pitch with YIN algorithm.
         Default is 8000.
+    trough_threshold: float
+        Absolute threshold for peak estimation.
+        A float greater than 0.
+        Used by :func:`pitch`.
 
     Returns
     -------
@@ -428,7 +432,8 @@ def similarity_features(
         audio, n_fft, hop_length, freq_range
     )
     amp_ = amplitude(power_spectrogram, min_freq, max_freq, amp_baseline)
-    pitch_ = pitch(audio, min_freq, fmax_yin, frame_length=n_fft, hop_length=hop_length)
+    pitch_ = pitch(audio, min_freq, fmax_yin,
+                   frame_length=n_fft, hop_length=hop_length, trough_threshold=trough_threshold)
     goodness_ = goodness_of_pitch(cepstrogram, quefrencies, max_F0)
     FM = frequency_modulation(dSdt, dSdf)
     AM = amplitude_modulation(dSdt)

--- a/src/vocalpy/feature/sat.py
+++ b/src/vocalpy/feature/sat.py
@@ -304,7 +304,7 @@ def amplitude(
     return 10 * np.log10(np.sum(P, axis=0)) + baseline
 
 
-def pitch(audio: Audio, fmin: float = 380.0, fmax_yin: float = 8000.0, frame_length: int = 400, hop_length: int = 40, trough_threshold: scalar = 0.1 ):
+def pitch(audio: Audio, fmin: float = 380.0, fmax_yin: float = 8000.0, frame_length: int = 400, hop_length: int = 40, trough_threshold: float = 0.1 ):
     """Estimates the fundamental frequency (or pitch) using the YIN algorithm.
 
     Returns:
@@ -327,7 +327,7 @@ def pitch(audio: Audio, fmin: float = 380.0, fmax_yin: float = 8000.0, frame_len
         number of audio samples between adjacent YIN predictions.
         If ``None``, defaults to ``frame_length // 4``.
         Default is 40.
-    trough_threshold: number > 0 [scalar]
+    trough_threshold: float > 0
         absolute threshold for peak estimation.
 
     Returns

--- a/src/vocalpy/feature/sat.py
+++ b/src/vocalpy/feature/sat.py
@@ -304,7 +304,7 @@ def amplitude(
     return 10 * np.log10(np.sum(P, axis=0)) + baseline
 
 
-def pitch(audio: Audio, fmin: float = 380.0, fmax_yin: float = 8000.0, frame_length: int = 400, hop_length: int = 40):
+def pitch(audio: Audio, fmin: float = 380.0, fmax_yin: float = 8000.0, frame_length: int = 400, hop_length: int = 40, trough_threshold: scalar = 0.1 ):
     """Estimates the fundamental frequency (or pitch) using the YIN algorithm.
 
     Returns:
@@ -327,6 +327,8 @@ def pitch(audio: Audio, fmin: float = 380.0, fmax_yin: float = 8000.0, frame_len
         number of audio samples between adjacent YIN predictions.
         If ``None``, defaults to ``frame_length // 4``.
         Default is 40.
+    trough_threshold: number > 0 [scalar]
+        absolute threshold for peak estimation.
 
     Returns
     -------
@@ -353,6 +355,7 @@ def pitch(audio: Audio, fmin: float = 380.0, fmax_yin: float = 8000.0, frame_len
         sr=audio.samplerate,
         frame_length=frame_length,
         hop_length=hop_length,
+       trough_threshold=trough_threshold
     )
 
 

--- a/src/vocalpy/spectrogram_maker.py
+++ b/src/vocalpy/spectrogram_maker.py
@@ -87,6 +87,7 @@ class SpectrogramMaker:
     def __init__(self, callback: Callable | None = None, spect_params: dict | None = None):
         if callback is None:
             import vocalpy.spectrogram
+
             callback = vocalpy.spectrogram
         if not callable(callback):
             raise ValueError(f"`callback` should be callable, but `callable({callback})` returns False")


### PR DESCRIPTION
I was trying to compute the fundamental frequency of some ultrasonic vocalizations and noticed that the [pitch](https://github.com/ralphpeterson/vocalpy/blob/main/src/vocalpy/feature/sat.py#L307) function (vocalpy.feature.sat) returned wonky results. It turns out that the librosa [yin](https://librosa.org/doc/main/generated/librosa.yin.html) function referenced in `pitch` has an additional argument, `trough_threshold` that when changed helps produce better f0 estimates (see example below with black line showing f0 estimate from librosa.yin). Not sure exactly the underlying reason, but nonetheless we should have access to this argument in vocalpy.

In this PR I simply added `trough_threshold` as an argument in the `pitch` function.

![Untitled](https://github.com/vocalpy/vocalpy/assets/4031329/2da2af33-b7fb-4250-b730-bfd83cc8aa15)
