### PR TITLE
BUG: fix edge case with segmentation IR metrics, fixes #170

### DIFF
--- a/src/vocalpy/metrics/segmentation/ir.py
+++ b/src/vocalpy/metrics/segmentation/ir.py
@@ -304,6 +304,12 @@ def precision_recall_fscore(
     if metric not in {"precision", "recall", "fscore"}:
         raise ValueError(f'``metric`` must be one of: {{"precision", "recall", "fscore"}} but was: {metric}')
 
+    # edge case: if both reference and hypothesis have a length of zero, we have a score of 1.0
+    # but no hits. This is to avoid punishing the correct hypothesis that there are no boundaries.
+    # See https://github.com/vocalpy/vocalpy/issues/170
+    if len(reference) == 0 and len(hypothesis) == 0:
+        return 1.0, 0, IRMetricData(hits_ref=np.array([]), hits_hyp=np.array([]), diffs=np.array([]))
+
     # If we have no boundaries, we get no score.
     if len(reference) == 0 or len(hypothesis) == 0:
         return 0.0, 0, IRMetricData(hits_ref=np.array([]), hits_hyp=np.array([]), diffs=np.array([]))

--- a/tests/test_metrics/test_segmentation/test_ir.py
+++ b/tests/test_metrics/test_segmentation/test_ir.py
@@ -499,19 +499,6 @@ IR_METRICS_SINGLE_BOUNDARY_ARRAY_PARAMS_VALS = [
         expected_fscore=0.5454545454545454,
     ),
     # # edge cases
-    # no boundaries in either
-    IRMetricSingleBoundaryArrayTestCase(
-        reference=np.array([]),
-        hypothesis=np.array([]),
-        tolerance=0.5,
-        decimals=3,
-        expected_hits_ref=np.array([]),
-        expected_hits_hyp=np.array([]),
-        expected_diffs=np.array([]),
-        expected_precision=0.0,
-        expected_recall=0.0,
-        expected_fscore=0.0,
-    ),
     # no boundaries in reference
     IRMetricSingleBoundaryArrayTestCase(
         reference=np.array([]),
@@ -564,6 +551,20 @@ IR_METRICS_SINGLE_BOUNDARY_ARRAY_PARAMS_VALS = [
         expected_precision=1.0,
         expected_recall=0.5,
         expected_fscore=(2 * 1.0 * 0.5) / (1 + 0.5),  # 0.6666666666666666 (repeating)
+    ),
+    # this is a regression test
+    # see https://github.com/vocalpy/vocalpy/issues/170
+    IRMetricSingleBoundaryArrayTestCase(
+        reference=np.array([]),
+        hypothesis=np.array([]),
+        tolerance=None,
+        decimals=None,
+        expected_hits_ref=np.array([]),
+        expected_hits_hyp=np.array([]),
+        expected_diffs=np.array([]),
+        expected_precision=1.0,
+        expected_recall=1.0,
+        expected_fscore=1.0,
     ),
 ]
 


### PR DESCRIPTION
Segmentation IR metrics should return score of 1.0 when both reference and hypothesis have no boundaries. 
We don't want to punish correctly hypothesizing that there are no segment boundaries, see #170. This fixes that.